### PR TITLE
[OCS-3013] Add retry limit for socket timeout

### DIFF
--- a/lib/resty/cassandra/cluster.lua
+++ b/lib/resty/cassandra/cluster.lua
@@ -922,7 +922,10 @@ local function handle_error(self, err, cql_code, coordinator, request)
     if self.retry_on_timeout then
       local should_retry = self.retry_policy:on_connect_timeout(request)
       if should_retry then
+        log(ERR, _log_prefix, 'sending retry request, retry count - ', request.retries)
         return self:send_retry(request, 'timeout')
+      else
+        log(ERR, _log_prefix, 'Retries stopped', request.retries)
       end
     end
   else

--- a/lib/resty/cassandra/cluster.lua
+++ b/lib/resty/cassandra/cluster.lua
@@ -920,7 +920,7 @@ local function handle_error(self, err, cql_code, coordinator, request)
     end
   elseif err == 'timeout' then
     if self.retry_on_timeout then
-      local should_retry = self.retry_policy:on_socket_timeout(request)
+      local should_retry = self.retry_policy:on_connect_timeout(request)
       if should_retry then
         return self:send_retry(request, 'timeout')
       end

--- a/lib/resty/cassandra/cluster.lua
+++ b/lib/resty/cassandra/cluster.lua
@@ -956,10 +956,7 @@ local function handle_error(self, err, cql_code, coordinator, request)
     if self.retry_on_timeout then
       local should_retry = self.retry_policy:on_connect_timeout(request)
       if should_retry then
-        log(ERR, _log_prefix, 'sending retry request, retry count - ', request.retries)
         return self:send_retry(request, 'timeout')
-      else
-        log(ERR, _log_prefix, 'Retries stopped', request.retries)
       end
     end
   else

--- a/lib/resty/cassandra/cluster.lua
+++ b/lib/resty/cassandra/cluster.lua
@@ -920,7 +920,10 @@ local function handle_error(self, err, cql_code, coordinator, request)
     end
   elseif err == 'timeout' then
     if self.retry_on_timeout then
-      return self:send_retry(request, 'timeout')
+      local should_retry = self.retry_policy:on_socket_timeout(request)
+      if should_retry then
+        return self:send_retry(request, 'timeout')
+      end
     end
   else
     -- host seems down?

--- a/lib/resty/cassandra/policies/retry/init.lua
+++ b/lib/resty/cassandra/policies/retry/init.lua
@@ -6,7 +6,7 @@ function _M.new_policy(name)
     on_unavailable = function() error('on_unavailable() not implemented') end,
     on_read_timeout = function() error('on_read_timeout() not implemented') end,
     on_write_timeout = function() error('on_write_timeout() not implemented') end,
-    on_socket_timeout = function() error('on_socket_timeout() not implemented') end,
+    on_connect_timeout = function() error('on_connect_timeout() not implemented') end,
   }
 
   retry_mt.__index = retry_mt

--- a/lib/resty/cassandra/policies/retry/init.lua
+++ b/lib/resty/cassandra/policies/retry/init.lua
@@ -6,6 +6,7 @@ function _M.new_policy(name)
     on_unavailable = function() error('on_unavailable() not implemented') end,
     on_read_timeout = function() error('on_read_timeout() not implemented') end,
     on_write_timeout = function() error('on_write_timeout() not implemented') end,
+    on_socket_timeout = function() error('on_socket_timeout() not implemented') end,
   }
 
   retry_mt.__index = retry_mt

--- a/lib/resty/cassandra/policies/retry/simple.lua
+++ b/lib/resty/cassandra/policies/retry/simple.lua
@@ -24,14 +24,21 @@ local type = type
 --
 -- @param[type=number] max_retries Maximum number of retries for a query
 -- before aborting and reporting the error.
+-- @param[type=number] max_retries_socket_timeout Maximum number of retries when connection timeout happens
+-- before aborting and reporting the error.
 -- @treturn table `policy`: A simple retry policy.
-function _M.new(max_retries)
+function _M.new(max_retries, max_retries_socket_timeout)
   if type(max_retries) ~= 'number' or max_retries < 1 then
     error('arg #1 max_retries must be a positive integer', 2)
   end
 
+  if max_retries_socket_timeout and type(max_retries_socket_timeout) ~= 'number' or max_retries < 1 then
+    error('arg #2 socket_timeout_max_retries must be a positive integer', 2)
+  end
+
   local self = _M.super.new()
   self.max_retries = max_retries
+  self.max_retries_socket_timeout = max_retries_socket_timeout
   return self
 end
 
@@ -45,6 +52,10 @@ end
 
 function _M:on_write_timeout(request)
   return request.retries < self.max_retries
+end
+
+function _M:on_socket_timeout(request)
+  return not self.max_retries_socket_timeout or request.retries < self.max_retries_socket_timeout
 end
 
 return _M

--- a/lib/resty/cassandra/policies/retry/simple.lua
+++ b/lib/resty/cassandra/policies/retry/simple.lua
@@ -24,21 +24,21 @@ local type = type
 --
 -- @param[type=number] max_retries Maximum number of retries for a query
 -- before aborting and reporting the error.
--- @param[type=number] max_retries_socket_timeout Maximum number of retries when connection timeout happens
+-- @param[type=number] max_retries_timeout_connect Maximum number of retries when connection timeout happens
 -- before aborting and reporting the error.
 -- @treturn table `policy`: A simple retry policy.
-function _M.new(max_retries, max_retries_socket_timeout)
+function _M.new(max_retries, max_retries_timeout_connect)
   if type(max_retries) ~= 'number' or max_retries < 1 then
     error('arg #1 max_retries must be a positive integer', 2)
   end
 
-  if max_retries_socket_timeout and type(max_retries_socket_timeout) ~= 'number' or max_retries < 1 then
+  if max_retries_timeout_connect and type(max_retries_timeout_connect) ~= 'number' or max_retries < 1 then
     error('arg #2 socket_timeout_max_retries must be a positive integer', 2)
   end
 
   local self = _M.super.new()
   self.max_retries = max_retries
-  self.max_retries_socket_timeout = max_retries_socket_timeout
+  self.max_retries_timeout_connect = max_retries_timeout_connect
   return self
 end
 
@@ -54,8 +54,8 @@ function _M:on_write_timeout(request)
   return request.retries < self.max_retries
 end
 
-function _M:on_socket_timeout(request)
-  return not self.max_retries_socket_timeout or request.retries < self.max_retries_socket_timeout
+function _M:on_connect_timeout(request)
+  return not self.max_retries_timeout_connect or request.retries < self.max_retries_timeout_connect
 end
 
 return _M

--- a/lib/resty/cassandra/policies/retry/simple.lua
+++ b/lib/resty/cassandra/policies/retry/simple.lua
@@ -24,21 +24,14 @@ local type = type
 --
 -- @param[type=number] max_retries Maximum number of retries for a query
 -- before aborting and reporting the error.
--- @param[type=number] max_retries_timeout_connect Maximum number of retries when connection timeout happens
--- before aborting and reporting the error.
 -- @treturn table `policy`: A simple retry policy.
-function _M.new(max_retries, max_retries_timeout_connect)
+function _M.new(max_retries)
   if type(max_retries) ~= 'number' or max_retries < 1 then
     error('arg #1 max_retries must be a positive integer', 2)
   end
 
-  if max_retries_timeout_connect and type(max_retries_timeout_connect) ~= 'number' or max_retries < 1 then
-    error('arg #2 socket_timeout_max_retries must be a positive integer', 2)
-  end
-
   local self = _M.super.new()
   self.max_retries = max_retries
-  self.max_retries_timeout_connect = max_retries_timeout_connect
   return self
 end
 
@@ -55,7 +48,7 @@ function _M:on_write_timeout(request)
 end
 
 function _M:on_connect_timeout(request)
-  return not self.max_retries_timeout_connect or request.retries < self.max_retries_timeout_connect
+  return request.retries < self.max_retries
 end
 
 return _M


### PR DESCRIPTION
We want to add limit for number of retries in case of tcp socket timeout. We will use retry_max parameter used for cql error retries to limit retries on socket timeout.