### PR TITLE
Add rack-aware request load balancing policy

### DIFF
--- a/lib/resty/cassandra/cluster.lua
+++ b/lib/resty/cassandra/cluster.lua
@@ -42,10 +42,16 @@ end
 -----------------------------------------
 
 local function set_peer(self, host, up, reconn_delay, unhealthy_at,
-                        data_center, connect_err, release_version, add)
+                        data_center, connect_err, release_version, rack, add)
+  if type(rack) == 'boolean' then
+    add = rack
+    rack = ''
+  end
+
   data_center = data_center or ''
   connect_err = connect_err or ''
   release_version = release_version or ''
+  rack = rack or ''
 
   local method = add and 'safe_add' or 'safe_set'
 
@@ -56,9 +62,9 @@ local function set_peer(self, host, up, reconn_delay, unhealthy_at,
   end
 
   -- host info
-  local marshalled = fmt("%d:%d:%d:%d:%s%s%s", reconn_delay, unhealthy_at,
-                         #data_center, #connect_err, data_center, connect_err,
-                         release_version)
+  local marshalled = fmt("%d:%d:%d:%d:%d:%s%s%s%s", reconn_delay, unhealthy_at,
+                         #data_center, #connect_err, #rack,
+                         data_center, connect_err, rack, release_version)
 
   ok, err = self.shm[method](self.shm, _rec_key..host, marshalled)
   if not ok and err ~= "exists" then
@@ -69,9 +75,9 @@ local function set_peer(self, host, up, reconn_delay, unhealthy_at,
 end
 
 local function add_peer(self, host, up, reconn_delay, unhealthy_at,
-                        data_center, connect_err, release_version)
+                        data_center, connect_err, release_version, rack)
   return set_peer(self, host, up, reconn_delay, unhealthy_at, data_center, nil,
-                  release_version, true)
+                  release_version, rack, true)
 end
 
 local function get_peer(self, host, status)
@@ -105,23 +111,40 @@ local function get_peer(self, host, status)
   local sep_2 = find(marshalled, ":", sep_1 + 1, true)
   local sep_3 = find(marshalled, ":", sep_2 + 1, true)
   local sep_4 = find(marshalled, ":", sep_3 + 1, true)
+  local sep_5 = find(marshalled, ":", sep_4 + 1, true)
 
   local reconn_delay    = sub(marshalled, 1, sep_1 - 1)
   local unhealthy_at    = sub(marshalled, sep_1 + 1, sep_2 - 1)
   local data_center_len = sub(marshalled, sep_2 + 1, sep_3 - 1)
   local err_len         = sub(marshalled, sep_3 + 1, sep_4 - 1)
 
-  local data_center_last = sep_4 + tonumber(data_center_len)
-  local err_last = data_center_last + tonumber(err_len)
+  local data_center, err_conn, rack, release_version
 
-  local data_center     = sub(marshalled, sep_4 + 1, data_center_last)
-  local err_conn        = sub(marshalled, data_center_last + 1, err_last)
-  local release_version = sub(marshalled, err_last + 1)
+  if sep_5 and tonumber(sub(marshalled, sep_4 + 1, sep_5 - 1)) then
+    local rack_len = tonumber(sub(marshalled, sep_4 + 1, sep_5 - 1))
+    local data_center_last = sep_5 + tonumber(data_center_len)
+    local err_last = data_center_last + tonumber(err_len)
+    local rack_last = err_last + rack_len
+
+    data_center = sub(marshalled, sep_5 + 1, data_center_last)
+    err_conn = sub(marshalled, data_center_last + 1, err_last)
+    rack = sub(marshalled, err_last + 1, rack_last)
+    release_version = sub(marshalled, rack_last + 1)
+  else
+    local data_center_last = sep_4 + tonumber(data_center_len)
+    local err_last = data_center_last + tonumber(err_len)
+
+    data_center = sub(marshalled, sep_4 + 1, data_center_last)
+    err_conn = sub(marshalled, data_center_last + 1, err_last)
+    rack = nil
+    release_version = sub(marshalled, err_last + 1)
+  end
 
   return {
     up = status,
     host = host,
     data_center = data_center ~= '' and data_center or nil,
+    rack = rack ~= '' and rack or nil,
     release_version = release_version ~= '' and release_version or nil,
     reconn_delay = tonumber(reconn_delay),
     unhealthy_at = tonumber(unhealthy_at),
@@ -195,7 +218,7 @@ local function set_peer_down(self, host, connect_err)
   peer = peer or empty_t -- this can be called from refresh() so no host in shm yet
 
   return set_peer(self, host, false, self.reconn_policy:next_delay(host), get_now(),
-                  peer.data_center, connect_err, peer.release_version)
+                  peer.data_center, connect_err, peer.release_version, peer.rack)
 end
 
 local function set_peer_up(self, host)
@@ -208,7 +231,7 @@ local function set_peer_up(self, host)
   peer = peer or empty_t -- this can be called from refresh() so no host in shm yet
 
   return set_peer(self, host, true, 0, 0,
-                  peer.data_center, nil, peer.release_version)
+                  peer.data_center, nil, peer.release_version, peer.rack)
 end
 
 local  function set_peer_maintenance(self, host, maintenance)
@@ -626,7 +649,7 @@ function _Cluster:refresh(timeout)
       coordinator:settimeout(self.timeout_read)
 
       local local_rows, err = coordinator:execute [[
-        SELECT data_center,rpc_address,release_version FROM system.local
+        SELECT data_center,rack,rpc_address,release_version FROM system.local
       ]]
       if not local_rows then
         return err_with_unlock(lock, err)
@@ -637,7 +660,7 @@ function _Cluster:refresh(timeout)
       end
 
       local rows, err = coordinator:execute [[
-        SELECT peer,data_center,rpc_address,release_version FROM system.peers
+        SELECT peer,data_center,rack,rpc_address,release_version FROM system.peers
       ]]
       if not rows then
         return err_with_unlock(lock, err)
@@ -661,6 +684,7 @@ function _Cluster:refresh(timeout)
       rows[#rows+1] = { -- local host
         rpc_address = local_addr,
         data_center = local_rows[1].data_center,
+        rack = local_rows[1].rack,
         release_version = local_rows[1].release_version
       }
 
@@ -722,7 +746,7 @@ function _Cluster:refresh(timeout)
           else
             local ok, err = add_peer(self, rows[i].host, true, 0, 0,
                                      rows[i].data_center, nil,
-                                     rows[i].release_version)
+                                     rows[i].release_version, rows[i].rack)
             if not ok then return err_with_unlock(lock, err) end
           end
         end

--- a/lib/resty/cassandra/policies/lb/req_dc_rack_rr.lua
+++ b/lib/resty/cassandra/policies/lb/req_dc_rack_rr.lua
@@ -1,0 +1,154 @@
+--- Request, datacenter and rack-aware round robin load balancing policy for OpenResty.
+-- This policy will try to reuse the same node for the lifecycle of a given
+-- request if possible. It is mostly designed for use in OpenResty
+-- environments.
+--
+-- This extends the request and datacenter-aware policy with rack preference
+-- (ideal for AWS AZs as racks).
+--
+-- Priority: same rack (in local DC) > other racks in local DC > remote DCs.
+-- @module resty.cassandra.policies.lb.req_dc_rack_rr
+
+local cluster = require "resty.cassandra.cluster"
+local _M = require('resty.cassandra.policies.lb').new_policy('req_dc_rack_aware_round_robin')
+
+local past_init
+
+--- Create a request, DC and rack-aware round robin policy.
+-- Instanciates a request, DC and rack-aware round robin policy for
+-- `resty.cassandra.cluster`.
+--
+-- @usage
+-- local Cluster = require "resty.cassandra.cluster"
+-- local req_dc_rack_rr = require "resty.cassandra.policies.lb.req_dc_rack_rr"
+--
+-- local policy = req_dc_rack_rr.new("my_local_cluster_name", "my_local_rack")
+-- local cluster = assert(Cluster.new {
+--   lb_policy = policy
+-- })
+--
+-- @param[type=string] local_dc Name of the local/closest datacenter.
+-- @param[type=string] local_rack (optional) Name of the local rack/AZ.
+--   If omitted, falls back to DC-only behavior.
+-- @treturn table `policy`: A DC and rack-aware round robin policy.
+function _M.new(local_dc, local_rack)
+  assert(type(local_dc) == 'string', 'local_dc must be a string')
+  if local_rack ~= nil then
+    assert(type(local_rack) == 'string', 'local_rack must be a string')
+  end
+
+  local self = _M.super.new()
+  self.local_dc = local_dc
+  self.local_rack = local_rack
+  return self
+end
+
+function _M:init(peers)
+  local same_rack, local_other_rack, remote = {}, {}, {}
+
+  for i = 1, #peers do
+    local peer = peers[i]
+    if type(peer.data_center) ~= 'string' then
+      ngx.log(ngx.WARN, cluster._log_prefix, 'peer ', peer.host,
+              ' has no data_center field in shm, considering it remote')
+      peer.data_center = nil
+    end
+    if type(peer.rack) ~= 'string' then
+      peer.rack = nil
+    end
+
+    if self.local_dc and peer.data_center == self.local_dc then
+      if self.local_rack and peer.rack == self.local_rack then
+        same_rack[#same_rack + 1] = peer
+      else
+        local_other_rack[#local_other_rack + 1] = peer
+      end
+    else
+      remote[#remote + 1] = peer
+    end
+  end
+
+  self.start_same_idx = -2
+  self.start_local_other_idx = -2
+  self.start_remote_idx = -2
+  self.same_rack_peers = same_rack
+  self.local_other_rack_peers = local_other_rack
+  self.remote_peers = remote
+end
+
+local function advance_peer(state)
+  if state.same_tried < #state.same_rack_peers then
+    state.same_tried = state.same_tried + 1
+    state.same_idx = state.same_idx + 1
+    return state.same_rack_peers[(state.same_idx % #state.same_rack_peers) + 1]
+
+  elseif state.local_other_tried < #state.local_other_rack_peers then
+    state.local_other_tried = state.local_other_tried + 1
+    state.local_other_idx = state.local_other_idx + 1
+    return state.local_other_rack_peers[(state.local_other_idx % #state.local_other_rack_peers) + 1]
+
+  elseif state.remote_tried < #state.remote_peers then
+    state.remote_tried = state.remote_tried + 1
+    state.remote_idx = state.remote_idx + 1
+    return state.remote_peers[(state.remote_idx % #state.remote_peers) + 1]
+  end
+end
+
+local function next_peer(state, i)
+  i = i + 1
+
+  if i == 1 and state.initial_cassandra_coordinator then
+    return i, state.initial_cassandra_coordinator
+  end
+
+  local peer = advance_peer(state)
+  if not peer then
+    return nil
+  end
+
+  if peer == state.initial_cassandra_coordinator then
+    peer = advance_peer(state)
+    if not peer then
+      return nil
+    end
+  end
+
+  if state.ctx then
+    state.ctx.cassandra_coordinator = peer
+  end
+
+  return i + 1, peer
+end
+
+function _M:iter()
+  self.same_tried = 0
+  self.local_other_tried = 0
+  self.remote_tried = 0
+
+  if past_init or ngx.get_phase() ~= "init" then
+    self.ctx = ngx and ngx.ctx
+    past_init = true
+  end
+
+  if self.ctx then
+    self.initial_cassandra_coordinator = self.ctx.cassandra_coordinator
+  end
+
+  if #self.same_rack_peers > 0 then
+    self.same_idx = (self.start_same_idx % #self.same_rack_peers) + 1
+  end
+  if #self.local_other_rack_peers > 0 then
+    self.local_other_idx = (self.start_local_other_idx % #self.local_other_rack_peers) + 1
+  end
+  if #self.remote_peers > 0 then
+    self.remote_idx = (self.start_remote_idx % #self.remote_peers) + 1
+  end
+
+  self.start_same_idx = self.start_same_idx + 1
+  self.start_local_other_idx = self.start_local_other_idx + 1
+  self.start_remote_idx = self.start_remote_idx + 1
+
+  return next_peer, self, 0
+end
+
+return _M

--- a/t/16-lb_req_dc_rack_rr.t
+++ b/t/16-lb_req_dc_rack_rr.t
@@ -1,0 +1,181 @@
+# vim:set ts=4 sw=4 et fdm=marker:
+use lib '.';
+use Test::Nginx::Socket::Lua;
+use t::Util;
+
+no_long_string();
+
+plan tests => repeat_each() * blocks() * 3;
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: lb_req_dc_rack_rr sanity
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local req_dc_rack_rr = require 'resty.cassandra.policies.lb.req_dc_rack_rr'
+            ngx.say(req_dc_rack_rr.name)
+
+            local peers = {
+                {host = '10.0.0.1', data_center = 'dc2', rack = 'rack1'},
+                {host = '10.0.0.2', data_center = 'dc2', rack = 'rack2'},
+                {host = '10.0.0.3', data_center = 'dc2', rack = 'rack2'},
+
+                {host = '127.0.0.1', data_center = 'dc1', rack = 'rack1'},
+                {host = '127.0.0.2', data_center = 'dc1', rack = 'rack1'},
+                {host = '127.0.0.3', data_center = 'dc1', rack = 'rack2'},
+            }
+
+            local lb = req_dc_rack_rr.new('dc1', 'rack1')
+            ngx.say('local_dc: ', lb.local_dc)
+            ngx.say('local_rack: ', lb.local_rack)
+
+            lb:init(peers)
+
+            ngx.say()
+            for i, peer in lb:iter() do
+                ngx.say("1. ", peer.host)
+            end
+
+            ngx.say()
+            for i, peer in lb:iter() do
+                ngx.say("2. ", peer.host)
+            end
+
+            ngx.say()
+            for i, peer in lb:iter() do
+                ngx.say("3. ", peer.host)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+req_dc_rack_aware_round_robin
+local_dc: dc1
+local_rack: rack1
+
+1. 127.0.0.1
+1. 127.0.0.2
+1. 127.0.0.3
+1. 10.0.0.1
+1. 10.0.0.2
+1. 10.0.0.3
+
+2. 127.0.0.2
+2. 127.0.0.1
+2. 127.0.0.3
+2. 10.0.0.2
+2. 10.0.0.3
+2. 10.0.0.1
+
+3. 127.0.0.1
+3. 127.0.0.2
+3. 127.0.0.3
+3. 10.0.0.3
+3. 10.0.0.1
+3. 10.0.0.2
+--- no_error_log
+[error]
+
+
+
+=== TEST 2: lb_req_dc_rack_rr falls back to DC-only when local_rack omitted
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local req_dc_rack_rr = require 'resty.cassandra.policies.lb.req_dc_rack_rr'
+
+            local peers = {
+                {host = '10.0.0.1', data_center = 'dc2', rack = 'rack1'},
+
+                {host = '127.0.0.1', data_center = 'dc1', rack = 'rack1'},
+                {host = '127.0.0.2', data_center = 'dc1', rack = 'rack2'},
+                {host = '127.0.0.3', data_center = 'dc1', rack = 'rack2'},
+            }
+
+            local lb = req_dc_rack_rr.new('dc1')
+            lb:init(peers)
+
+            for i, peer in lb:iter() do
+                ngx.say(peer.host)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+127.0.0.1
+127.0.0.2
+127.0.0.3
+10.0.0.1
+--- no_error_log
+[error]
+
+
+
+=== TEST 3: lb_req_dc_rack_rr returns same host first when invoked multiple times
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local req_dc_rack_rr = require 'resty.cassandra.policies.lb.req_dc_rack_rr'
+
+            local peers = {
+                {host = '10.0.0.1', data_center = 'dc2', rack = 'rack1'},
+
+                {host = '127.0.0.1', data_center = 'dc1', rack = 'rack1'},
+                {host = '127.0.0.2', data_center = 'dc1', rack = 'rack1'},
+                {host = '127.0.0.3', data_center = 'dc1', rack = 'rack2'},
+            }
+
+            local lb = req_dc_rack_rr.new('dc1', 'rack1')
+            lb:init(peers)
+
+            for i, peer in lb:iter() do
+                ngx.say("1. ", peer.host)
+                break
+            end
+
+            for i, peer in lb:iter() do
+                ngx.say("2. ", peer.host)
+                break
+            end
+
+            for i, peer in lb:iter() do
+                ngx.say("3. ", peer.host)
+                break
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+1. 127.0.0.1
+2. 127.0.0.1
+3. 127.0.0.1
+--- no_error_log
+[error]
+
+
+
+=== TEST 4: lb_req_dc_rack_rr with missing local_dc
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local req_dc_rack_rr = require 'resty.cassandra.policies.lb.req_dc_rack_rr'
+            local lb = req_dc_rack_rr.new()
+        }
+    }
+--- request
+GET /t
+--- error_code: 500
+--- error_log
+local_dc must be a string
+--- no_error_log
+[crit]


### PR DESCRIPTION
## Summary
- Add `req_dc_rack_rr` load balancing policy that extends `req_dc_rr` with rack/AZ preference: same rack in local DC → other racks in local DC → remote DCs.
- Extend `cluster.lua` to discover and persist `rack` from `system.local` / `system.peers`, with backward-compatible shm parsing for existing peer records.
- Add Test::Nginx coverage in `t/16-lb_req_dc_rack_rr.t`.

## Usage
```lua
local Cluster = require "resty.cassandra.cluster"
local req_dc_rack_rr = require "resty.cassandra.policies.lb.req_dc_rack_rr"

local policy = req_dc_rack_rr.new("us-east-1", "us-east-1a")
local cluster = assert(Cluster.new {
  shm = "cassandra",
  contact_points = { "10.0.1.10" },
  lb_policy = policy,
})
```

## Test plan
- [ ] `prove -I. t/16-lb_req_dc_rack_rr.t`
- [ ] `prove -I. t/14-lb_req_dc_rr.t` (regression)
- [ ] `prove -I. t/06-cluster.t` (peer shm round-trip)
- [ ] Verify in staging that coordinators are selected from the local AZ first


Made with [Cursor](https://cursor.com)