### PR TITLE
fix(cluster): reconnect from contact_points when all peers change IP

### DIFF
--- a/lib/resty/cassandra/cluster.lua
+++ b/lib/resty/cassandra/cluster.lua
@@ -518,7 +518,10 @@ local function next_coordinator(self, coordinator_options)
         errors[peer_rec.host] = err
       end
     elseif err then
-      return nil, err
+      -- This is an internal state error, not evidence that the topology is
+      -- stale. Let callers distinguish it from an exhausted host list so they
+      -- do not hide it behind an unrelated refresh attempt.
+      return nil, err, false
     else
       local s = 'host still considered down'
       if peer_state then
@@ -536,7 +539,43 @@ local function next_coordinator(self, coordinator_options)
     end
   end
 
-  return nil, no_host_available_error(errors)
+  return nil, no_host_available_error(errors), true
+end
+
+-- When every known peer is down, the topology stored in the shm only holds
+-- stale addresses (e.g. IPs of nodes that have since been replaced). The only
+-- way back to a healthy cluster is to re-resolve the configured
+-- `contact_points` (which may be DNS names) and rebuild the topology from them.
+-- `next_coordinator` on its own never does this, so a cluster whose nodes all
+-- changed address would stay permanently unreachable. This wrapper detects the
+-- all-down case, forces a topology refresh from the contact points, and retries
+-- the coordinator selection once.
+local function next_coordinator_with_refresh(self, coordinator_options)
+  local coordinator, err, refreshable = next_coordinator(self, coordinator_options)
+  if coordinator then
+    return coordinator
+  end
+
+  if not refreshable then
+    return nil, err
+  end
+
+  if self.logging then
+    log(ERR, _log_prefix, 'no coordinator available (', err, '), refreshing ',
+                          'topology from contact points')
+  end
+
+  -- Refresh re-resolves the contact points and rebuilds the topology. When
+  -- this worker still holds the latest topo version, refresh re-runs
+  -- first_coordinator (resolving the possibly-DNS contact points afresh); when
+  -- another worker already rebuilt it, refresh just adopts the newer topology.
+  local ok, refresh_err = self:refresh()
+  if not ok then
+    -- keep the original all-down error, but surface why recovery failed too
+    return nil, err .. ' (topology refresh failed: ' .. refresh_err .. ')'
+  end
+
+  return next_coordinator(self, coordinator_options)
 end
 
 local function compare_peers(t1, t2, tc)
@@ -894,7 +933,7 @@ end
 local send_request
 
 function _Cluster:send_retry(request, ...)
-  local coordinator, err = next_coordinator(self)
+  local coordinator, err = next_coordinator_with_refresh(self)
   if not coordinator then return nil, err end
 
   if self.logging then
@@ -1064,7 +1103,7 @@ do
 
     coordinator_options = coordinator_options or empty_t
 
-    local coordinator, err = next_coordinator(self, coordinator_options)
+    local coordinator, err = next_coordinator_with_refresh(self, coordinator_options)
     if not coordinator then return nil, err end
 
     log(ERR, _log_prefix, 'coordinator: protocol_version (protocol_version=', coordinator.protocol_version, ')')
@@ -1121,7 +1160,7 @@ do
 
     coordinator_options = coordinator_options or empty_t
 
-    local coordinator, err = next_coordinator(self, coordinator_options)
+    local coordinator, err = next_coordinator_with_refresh(self, coordinator_options)
     if not coordinator then return nil, err end
 
     local opts = get_request_opts(options)
@@ -1179,6 +1218,7 @@ _Cluster.handle_error = handle_error
 _Cluster.set_peer_down = set_peer_down
 _Cluster.get_or_prepare = get_or_prepare
 _Cluster.next_coordinator = next_coordinator
+_Cluster.next_coordinator_with_refresh = next_coordinator_with_refresh
 _Cluster.first_coordinator = first_coordinator
 _Cluster.wait_schema_consensus = wait_schema_consensus
 _Cluster.check_schema_consensus = check_schema_consensus

--- a/t/06-cluster.t
+++ b/t/06-cluster.t
@@ -1387,3 +1387,169 @@ GET /t
 system
 --- no_error_log
 [error]
+
+
+
+=== TEST 30: next_coordinator_with_refresh() returns coordinator without refreshing when one is available
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local Cluster = require 'resty.cassandra.cluster'
+            local cluster, err = Cluster.new()
+            if not cluster then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            local ok, err = cluster:refresh()
+            if not ok then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            local topo_ver_before = cluster.topo_ver
+
+            local coordinator, err = cluster:next_coordinator_with_refresh()
+            if not coordinator then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            ngx.say('coordinator: ', coordinator.host)
+            -- healthy path must not trigger a topology refresh
+            ngx.say('topo_ver unchanged: ', cluster.topo_ver == topo_ver_before)
+        }
+    }
+--- request
+GET /t
+--- response_body_like
+coordinator: 127\.0\.0\.\d+
+topo_ver unchanged: true
+--- no_error_log
+[error]
+
+
+
+=== TEST 31: next_coordinator_with_refresh() recovers when all peers are down by refreshing from contact_points
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local Cluster = require 'resty.cassandra.cluster'
+            local cluster, err = Cluster.new {
+                timeout_connect = 100
+            }
+            if not cluster then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            -- populate a real topology (127.0.0.1-3) from the live contact points
+            local ok, err = cluster:refresh()
+            if not ok then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            -- simulate every stored address having gone away: point the in-memory
+            -- load balancing policy at unreachable hosts, leaving the real
+            -- contact_points untouched. next_coordinator() will find all down.
+            local ok, err = cluster:set_peer_up('255.255.255.254')
+            if not ok then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            local ok, err = cluster:set_peers(cluster.topo_ver, {
+                { host = '255.255.255.254' },
+            })
+            if not ok then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            local fake_peers, err = cluster:get_peers(cluster.topo_ver)
+            if not fake_peers then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+            cluster.lb_policy:init(fake_peers)
+
+            -- with only an unreachable peer known, recovery must re-resolve the
+            -- contact points and return a real coordinator
+            local coordinator, err = cluster:next_coordinator_with_refresh()
+            if not coordinator then
+                ngx.log(ngx.ERR, 'expected recovery, got: ', err)
+                return
+            end
+
+            ngx.say('recovered coordinator: ', coordinator.host)
+        }
+    }
+--- request
+GET /t
+--- response_body_like
+recovered coordinator: 127\.0\.0\.\d+
+--- no_error_log
+[error]
+
+
+
+=== TEST 32: next_coordinator_with_refresh() surfaces combined error when refresh also fails
+--- http_config eval
+qq {
+    lua_socket_log_errors off;
+    $::HttpConfig
+}
+--- config
+    location /t {
+        content_by_lua_block {
+            local Cluster = require 'resty.cassandra.cluster'
+            local cluster, err = Cluster.new {
+                contact_points = { '255.255.255.254' },
+                timeout_connect = 100
+            }
+            if not cluster then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            -- known topology consists only of an unreachable host, and the
+            -- contact points are unreachable too, so recovery cannot succeed
+            local ok, err = cluster:set_peer_up('255.255.255.253')
+            if not ok then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            local ok, err = cluster:set_peers(1, {
+                { host = '255.255.255.253' },
+            })
+            if not ok then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            local peers, err = cluster:get_peers(1)
+            if not peers then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+            cluster.lb_policy:init(peers)
+
+            local coordinator, err = cluster:next_coordinator_with_refresh()
+            if coordinator then
+                ngx.log(ngx.ERR, 'expected failure, got coordinator ', coordinator.host)
+                return
+            end
+
+            ngx.say(err)
+        }
+    }
+--- request
+GET /t
+--- response_body_like chomp
+all hosts tried for query failed\..*\(topology refresh failed: .*255\.255\.255\.254.*\)
+--- no_error_log
+[error]


### PR DESCRIPTION
**Problem**

With DNS contact_points, if the Cassandra cluster's node IPs all change (rolling replacement, K8s reschedule, autoscaling), the client permanently loses connectivity and never recovers.

**Cause**

- DNS `contact_points` are consulted only on the first `refresh()`. After that, coordinators are selected from the IPs stored from `system.peers` - DNS names are never used again.
- `execute/batch` only auto-refreshes when `topo_ver == 0` (once per worker). So once every stored IP is dead, there's no working coordinator to rebuild the topology, and the DNS `contact_points` are never re-resolved -> permanent deadlock.

**Fix**

Added `next_coordinator_with_refresh`: when coordinator selection finds all peers down, force a `refresh()` (re-runs `first_coordinator`, re-resolving the possibly-DNS `contact_points`), rebuild the topology, and retry selection once. Wired into `execute`, `batch`, and `send_retry`.

- If the recovery refresh also fails, the original error is preserved and the refresh failure appended.
- Retry is bounded (single attempt) — no loop/recursion.
- No change to DNS mechanics: the library never pre-resolves a contact point to a fixed IP, so `socket:connect(name)` re-resolves on each fresh connection.