### PR TITLE
[PT-1392] expand cassandra lua driver functionality to support rack az fields

### DIFF
--- a/lib/cassandra/cql.lua
+++ b/lib/cassandra/cql.lua
@@ -900,7 +900,7 @@ Notes:
       [cql_types.blob]    = marsh_raw,
       [cql_types.boolean] = marsh_boolean,
       [cql_types.counter] = marsh_bigint,
-      [cql_types.decimal]    = marsh_decimal,
+      -- decimal (0x06) not yet implemented
       [cql_types.double]    = marsh_double,
       [cql_types.float]     = marsh_float,
       [cql_types.inet]      = marsh_inet,
@@ -976,7 +976,7 @@ Notes:
       [cql_types.blob]      = unmarsh_raw,
       [cql_types.boolean]   = unmarsh_boolean,
       [cql_types.counter]   = unmarsh_bigint,
-      [cql_types.decimal]    = unmarsh_decimal,
+      -- decimal (0x06) not yet implemented
       [cql_types.double]    = unmarsh_double,
       [cql_types.float]     = unmarsh_float,
       [cql_types.inet]      = unmarsh_inet,

--- a/lib/resty/cassandra/cluster.lua
+++ b/lib/resty/cassandra/cluster.lua
@@ -42,10 +42,16 @@ end
 -----------------------------------------
 
 local function set_peer(self, host, up, reconn_delay, unhealthy_at,
-                        data_center, connect_err, release_version, add)
+                        data_center, connect_err, release_version, rack, add)
+  if type(rack) == 'boolean' then
+    add = rack
+    rack = ''
+  end
+
   data_center = data_center or ''
   connect_err = connect_err or ''
   release_version = release_version or ''
+  rack = rack or ''
 
   local method = add and 'safe_add' or 'safe_set'
 
@@ -56,9 +62,9 @@ local function set_peer(self, host, up, reconn_delay, unhealthy_at,
   end
 
   -- host info
-  local marshalled = fmt("%d:%d:%d:%d:%s%s%s", reconn_delay, unhealthy_at,
-                         #data_center, #connect_err, data_center, connect_err,
-                         release_version)
+  local marshalled = fmt("%d:%d:%d:%d:%d:%s%s%s%s", reconn_delay, unhealthy_at,
+                         #data_center, #connect_err, #rack,
+                         data_center, connect_err, rack, release_version)
 
   ok, err = self.shm[method](self.shm, _rec_key..host, marshalled)
   if not ok and err ~= "exists" then
@@ -69,9 +75,9 @@ local function set_peer(self, host, up, reconn_delay, unhealthy_at,
 end
 
 local function add_peer(self, host, up, reconn_delay, unhealthy_at,
-                        data_center, connect_err, release_version)
+                        data_center, connect_err, release_version, rack)
   return set_peer(self, host, up, reconn_delay, unhealthy_at, data_center, nil,
-                  release_version, true)
+                  release_version, rack, true)
 end
 
 local function get_peer(self, host, status)
@@ -105,23 +111,42 @@ local function get_peer(self, host, status)
   local sep_2 = find(marshalled, ":", sep_1 + 1, true)
   local sep_3 = find(marshalled, ":", sep_2 + 1, true)
   local sep_4 = find(marshalled, ":", sep_3 + 1, true)
+  local sep_5 = find(marshalled, ":", sep_4 + 1, true)
 
   local reconn_delay    = sub(marshalled, 1, sep_1 - 1)
   local unhealthy_at    = sub(marshalled, sep_1 + 1, sep_2 - 1)
   local data_center_len = sub(marshalled, sep_2 + 1, sep_3 - 1)
   local err_len         = sub(marshalled, sep_3 + 1, sep_4 - 1)
 
-  local data_center_last = sep_4 + tonumber(data_center_len)
-  local err_last = data_center_last + tonumber(err_len)
+  local data_center, err_conn, rack, release_version
 
-  local data_center     = sub(marshalled, sep_4 + 1, data_center_last)
-  local err_conn        = sub(marshalled, data_center_last + 1, err_last)
-  local release_version = sub(marshalled, err_last + 1)
+  if sep_5 and tonumber(sub(marshalled, sep_4 + 1, sep_5 - 1)) then
+    -- new format: reconn:unhealthy:dc_len:err_len:rack_len:dc+err+rack+ver
+    local rack_len = tonumber(sub(marshalled, sep_4 + 1, sep_5 - 1))
+    local data_center_last = sep_5 + tonumber(data_center_len)
+    local err_last = data_center_last + tonumber(err_len)
+    local rack_last = err_last + rack_len
+
+    data_center     = sub(marshalled, sep_5 + 1, data_center_last)
+    err_conn        = sub(marshalled, data_center_last + 1, err_last)
+    rack            = sub(marshalled, err_last + 1, rack_last)
+    release_version = sub(marshalled, rack_last + 1)
+  else
+    -- old format: reconn:unhealthy:dc_len:err_len:dc+err+ver
+    local data_center_last = sep_4 + tonumber(data_center_len)
+    local err_last = data_center_last + tonumber(err_len)
+
+    data_center     = sub(marshalled, sep_4 + 1, data_center_last)
+    err_conn        = sub(marshalled, data_center_last + 1, err_last)
+    rack            = nil
+    release_version = sub(marshalled, err_last + 1)
+  end
 
   return {
     up = status,
     host = host,
     data_center = data_center ~= '' and data_center or nil,
+    rack = rack ~= '' and rack or nil,
     release_version = release_version ~= '' and release_version or nil,
     reconn_delay = tonumber(reconn_delay),
     unhealthy_at = tonumber(unhealthy_at),
@@ -195,7 +220,7 @@ local function set_peer_down(self, host, connect_err)
   peer = peer or empty_t -- this can be called from refresh() so no host in shm yet
 
   return set_peer(self, host, false, self.reconn_policy:next_delay(host), get_now(),
-                  peer.data_center, connect_err, peer.release_version)
+                  peer.data_center, connect_err, peer.release_version, peer.rack)
 end
 
 local function set_peer_up(self, host)
@@ -208,7 +233,7 @@ local function set_peer_up(self, host)
   peer = peer or empty_t -- this can be called from refresh() so no host in shm yet
 
   return set_peer(self, host, true, 0, 0,
-                  peer.data_center, nil, peer.release_version)
+                  peer.data_center, nil, peer.release_version, peer.rack)
 end
 
 local  function set_peer_maintenance(self, host, maintenance)
@@ -626,7 +651,7 @@ function _Cluster:refresh(timeout)
       coordinator:settimeout(self.timeout_read)
 
       local local_rows, err = coordinator:execute [[
-        SELECT data_center,rpc_address,release_version FROM system.local
+        SELECT data_center,rack,rpc_address,release_version FROM system.local
       ]]
       if not local_rows then
         return err_with_unlock(lock, err)
@@ -637,7 +662,7 @@ function _Cluster:refresh(timeout)
       end
 
       local rows, err = coordinator:execute [[
-        SELECT peer,data_center,rpc_address,release_version FROM system.peers
+        SELECT peer,data_center,rack,rpc_address,release_version FROM system.peers
       ]]
       if not rows then
         return err_with_unlock(lock, err)
@@ -661,6 +686,7 @@ function _Cluster:refresh(timeout)
       rows[#rows+1] = { -- local host
         rpc_address = local_addr,
         data_center = local_rows[1].data_center,
+        rack = local_rows[1].rack,
         release_version = local_rows[1].release_version
       }
 
@@ -720,9 +746,9 @@ function _Cluster:refresh(timeout)
                                   ' in ', coordinator.host, '\'s peers system ',
                                   'table. ', rows[i].peer, ' will be ignored.')
           else
-            local ok, err = add_peer(self, rows[i].host, true, 0, 0,
+            local ok, err = set_peer(self, rows[i].host, true, 0, 0,
                                      rows[i].data_center, nil,
-                                     rows[i].release_version)
+                                     rows[i].release_version, rows[i].rack)
             if not ok then return err_with_unlock(lock, err) end
           end
         end

--- a/lib/resty/cassandra/policies/lb/req_dc_rack_rr.lua
+++ b/lib/resty/cassandra/policies/lb/req_dc_rack_rr.lua
@@ -14,9 +14,6 @@
 local cluster = require "resty.cassandra.cluster"
 local _M = require('resty.cassandra.policies.lb').new_policy('req_dc_rack_aware_round_robin')
 
-local log = ngx.log
-local WARN = ngx.WARN
-local _log_prefix = cluster._log_prefix
 local past_init
 
 --- Create a request, DC and rack-aware round robin policy.
@@ -75,17 +72,6 @@ function _M:init(peers)
   self.same_rack_peers = same_rack
   self.local_other_rack_peers = local_other_rack
   self.remote_peers = remote
-
-  local function hosts_str(t)
-    local buf = {}
-    for i = 1, #t do buf[i] = t[i].host end
-    return table.concat(buf, ",")
-  end
-  log(WARN, _log_prefix, "req_dc_rack_rr init: dc=", self.local_dc,
-      " rack=", self.local_rack or "(nil)",
-      " | same_rack=[", hosts_str(same_rack),
-      "] local_other=[", hosts_str(local_other_rack),
-      "] remote=[", hosts_str(remote), "]")
 end
 
 local function advance_peer(state)
@@ -96,8 +82,6 @@ local function advance_peer(state)
     if state.ctx then
       state.ctx.cassandra_coordinator = peer
     end
-    log(WARN, _log_prefix, "req_dc_rack_rr: chose ", peer.host,
-        " (tier=same_rack, rack=", peer.rack or "?", ")")
     return peer
 
   elseif state.local_other_tried < #state.local_other_rack_peers then
@@ -107,17 +91,12 @@ local function advance_peer(state)
     if state.ctx then
       state.ctx.cassandra_coordinator = peer
     end
-    log(WARN, _log_prefix, "req_dc_rack_rr: chose ", peer.host,
-        " (tier=local_other_rack, rack=", peer.rack or "?", ")")
     return peer
 
   elseif state.remote_tried < #state.remote_peers then
     state.remote_tried = state.remote_tried + 1
     state.remote_idx = state.remote_idx + 1
-    local peer = state.remote_peers[(state.remote_idx % #state.remote_peers) + 1]
-    log(WARN, _log_prefix, "req_dc_rack_rr: chose ", peer.host,
-        " (tier=remote, dc=", peer.data_center or "?", ")")
-    return peer
+    return state.remote_peers[(state.remote_idx % #state.remote_peers) + 1]
   end
 end
 
@@ -125,8 +104,6 @@ local function next_peer(state, i)
   i = i + 1
 
   if i == 1 and state.initial_cassandra_coordinator then
-    log(WARN, _log_prefix, "req_dc_rack_rr: reusing sticky coordinator ",
-        state.initial_cassandra_coordinator.host)
     return i, state.initial_cassandra_coordinator
   end
 

--- a/lib/resty/cassandra/policies/lb/req_dc_rack_rr.lua
+++ b/lib/resty/cassandra/policies/lb/req_dc_rack_rr.lua
@@ -1,0 +1,156 @@
+--- Request, datacenter and rack-aware round robin load balancing policy for OpenResty.
+-- This policy will try to reuse the same node for the lifecycle of a given
+-- request if possible. It is mostly designed for use in OpenResty
+-- environments.
+--
+-- This extends the request and datacenter-aware policy with rack preference
+-- (ideal for cloud AZs which map to Cassandra racks).
+--
+-- Priority order: same rack in local DC > other racks in local DC > remote DCs.
+--
+-- If local_rack is not provided, this behaves identically to req_dc_rr.
+-- @module resty.cassandra.policies.lb.req_dc_rack_rr
+
+local cluster = require "resty.cassandra.cluster"
+local _M = require('resty.cassandra.policies.lb').new_policy('req_dc_rack_aware_round_robin')
+
+local past_init
+
+--- Create a request, DC and rack-aware round robin policy.
+-- @usage
+-- local Cluster = require "resty.cassandra.cluster"
+-- local req_dc_rack_rr = require "resty.cassandra.policies.lb.req_dc_rack_rr"
+--
+-- local policy = req_dc_rack_rr.new("my_dc", "my_rack")
+-- local cluster = assert(Cluster.new {
+--   lb_policy = policy
+-- })
+--
+-- @param[type=string] local_dc Name of the local/closest datacenter.
+-- @param[type=string] local_rack (optional) Name of the local rack/AZ.
+-- @treturn table `policy`: A DC and rack-aware round robin policy.
+function _M.new(local_dc, local_rack)
+  assert(type(local_dc) == 'string', 'local_dc must be a string')
+  if local_rack ~= nil then
+    assert(type(local_rack) == 'string', 'local_rack must be a string')
+  end
+
+  local self = _M.super.new()
+  self.local_dc = local_dc
+  self.local_rack = local_rack
+  return self
+end
+
+function _M:init(peers)
+  local same_rack, local_other_rack, remote = {}, {}, {}
+
+  for i = 1, #peers do
+    local peer = peers[i]
+    if type(peer.data_center) ~= 'string' then
+      ngx.log(ngx.WARN, cluster._log_prefix, 'peer ', peer.host,
+              ' has no data_center field in shm, considering it remote')
+      peer.data_center = nil
+    end
+    if type(peer.rack) ~= 'string' then
+      peer.rack = nil
+    end
+
+    if self.local_dc and peer.data_center == self.local_dc then
+      if self.local_rack and peer.rack == self.local_rack then
+        same_rack[#same_rack + 1] = peer
+      else
+        local_other_rack[#local_other_rack + 1] = peer
+      end
+    else
+      remote[#remote + 1] = peer
+    end
+  end
+
+  self.start_same_idx = -2
+  self.start_local_other_idx = -2
+  self.start_remote_idx = -2
+  self.same_rack_peers = same_rack
+  self.local_other_rack_peers = local_other_rack
+  self.remote_peers = remote
+end
+
+local function advance_peer(state)
+  if state.same_tried < #state.same_rack_peers then
+    state.same_tried = state.same_tried + 1
+    state.same_idx = state.same_idx + 1
+    local peer = state.same_rack_peers[(state.same_idx % #state.same_rack_peers) + 1]
+    if state.ctx then
+      state.ctx.cassandra_coordinator = peer
+    end
+    return peer
+
+  elseif state.local_other_tried < #state.local_other_rack_peers then
+    state.local_other_tried = state.local_other_tried + 1
+    state.local_other_idx = state.local_other_idx + 1
+    local peer = state.local_other_rack_peers[(state.local_other_idx % #state.local_other_rack_peers) + 1]
+    if state.ctx then
+      state.ctx.cassandra_coordinator = peer
+    end
+    return peer
+
+  elseif state.remote_tried < #state.remote_peers then
+    state.remote_tried = state.remote_tried + 1
+    state.remote_idx = state.remote_idx + 1
+    return state.remote_peers[(state.remote_idx % #state.remote_peers) + 1]
+  end
+end
+
+local function next_peer(state, i)
+  i = i + 1
+
+  if i == 1 and state.initial_cassandra_coordinator then
+    return i, state.initial_cassandra_coordinator
+  end
+
+  local peer = advance_peer(state)
+  if not peer then
+    return nil
+  end
+
+  if peer == state.initial_cassandra_coordinator then
+    peer = advance_peer(state)
+    if not peer then
+      return nil
+    end
+  end
+
+  return i + 1, peer
+end
+
+function _M:iter()
+  self.same_tried = 0
+  self.local_other_tried = 0
+  self.remote_tried = 0
+
+  if past_init or ngx.get_phase() ~= "init" then
+    self.ctx = ngx and ngx.ctx
+    past_init = true
+  end
+
+  if self.ctx then
+    self.initial_cassandra_coordinator = self.ctx.cassandra_coordinator
+  end
+
+  if #self.same_rack_peers > 0 then
+    self.same_idx = (self.start_same_idx % #self.same_rack_peers) + 1
+  end
+  if #self.local_other_rack_peers > 0 then
+    self.local_other_idx = (self.start_local_other_idx % #self.local_other_rack_peers) + 1
+  end
+  if #self.remote_peers > 0 then
+    self.remote_idx = (self.start_remote_idx % #self.remote_peers) + 1
+  end
+
+  self.start_same_idx = self.start_same_idx + 1
+  self.start_local_other_idx = self.start_local_other_idx + 1
+  self.start_remote_idx = self.start_remote_idx + 1
+
+  return next_peer, self, 0
+end
+
+return _M

--- a/lib/resty/cassandra/policies/lb/req_dc_rack_rr.lua
+++ b/lib/resty/cassandra/policies/lb/req_dc_rack_rr.lua
@@ -14,6 +14,9 @@
 local cluster = require "resty.cassandra.cluster"
 local _M = require('resty.cassandra.policies.lb').new_policy('req_dc_rack_aware_round_robin')
 
+local log = ngx.log
+local WARN = ngx.WARN
+local _log_prefix = cluster._log_prefix
 local past_init
 
 --- Create a request, DC and rack-aware round robin policy.
@@ -72,6 +75,17 @@ function _M:init(peers)
   self.same_rack_peers = same_rack
   self.local_other_rack_peers = local_other_rack
   self.remote_peers = remote
+
+  local function hosts_str(t)
+    local buf = {}
+    for i = 1, #t do buf[i] = t[i].host end
+    return table.concat(buf, ",")
+  end
+  log(WARN, _log_prefix, "req_dc_rack_rr init: dc=", self.local_dc,
+      " rack=", self.local_rack or "(nil)",
+      " | same_rack=[", hosts_str(same_rack),
+      "] local_other=[", hosts_str(local_other_rack),
+      "] remote=[", hosts_str(remote), "]")
 end
 
 local function advance_peer(state)
@@ -82,6 +96,8 @@ local function advance_peer(state)
     if state.ctx then
       state.ctx.cassandra_coordinator = peer
     end
+    log(WARN, _log_prefix, "req_dc_rack_rr: chose ", peer.host,
+        " (tier=same_rack, rack=", peer.rack or "?", ")")
     return peer
 
   elseif state.local_other_tried < #state.local_other_rack_peers then
@@ -91,12 +107,17 @@ local function advance_peer(state)
     if state.ctx then
       state.ctx.cassandra_coordinator = peer
     end
+    log(WARN, _log_prefix, "req_dc_rack_rr: chose ", peer.host,
+        " (tier=local_other_rack, rack=", peer.rack or "?", ")")
     return peer
 
   elseif state.remote_tried < #state.remote_peers then
     state.remote_tried = state.remote_tried + 1
     state.remote_idx = state.remote_idx + 1
-    return state.remote_peers[(state.remote_idx % #state.remote_peers) + 1]
+    local peer = state.remote_peers[(state.remote_idx % #state.remote_peers) + 1]
+    log(WARN, _log_prefix, "req_dc_rack_rr: chose ", peer.host,
+        " (tier=remote, dc=", peer.data_center or "?", ")")
+    return peer
   end
 end
 
@@ -104,6 +125,8 @@ local function next_peer(state, i)
   i = i + 1
 
   if i == 1 and state.initial_cassandra_coordinator then
+    log(WARN, _log_prefix, "req_dc_rack_rr: reusing sticky coordinator ",
+        state.initial_cassandra_coordinator.host)
     return i, state.initial_cassandra_coordinator
   end
 

--- a/t/16-lb_req_dc_rack_rr.t
+++ b/t/16-lb_req_dc_rack_rr.t
@@ -1,0 +1,313 @@
+# vim:set ts=4 sw=4 et fdm=marker:
+use lib '.';
+use Test::Nginx::Socket::Lua;
+use t::Util;
+
+no_long_string();
+
+plan tests => repeat_each() * blocks() * 3;
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: lb_req_dc_rack_rr sanity (3-tier ordering)
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local lb_mod = require 'resty.cassandra.policies.lb.req_dc_rack_rr'
+            ngx.say(lb_mod.name)
+
+            local peers = {
+                {host = '10.0.0.1', data_center = 'dc2', rack = 'rack1'},
+                {host = '10.0.0.2', data_center = 'dc2', rack = 'rack2'},
+
+                {host = '127.0.0.1', data_center = 'dc1', rack = 'rack1'},
+                {host = '127.0.0.2', data_center = 'dc1', rack = 'rack1'},
+                {host = '127.0.0.3', data_center = 'dc1', rack = 'rack2'},
+                {host = '127.0.0.4', data_center = 'dc1', rack = 'rack3'},
+            }
+
+            local lb = lb_mod.new('dc1', 'rack1')
+            ngx.say('local_dc: ', lb.local_dc)
+            ngx.say('local_rack: ', lb.local_rack)
+
+            lb:init(peers)
+
+            ngx.say()
+            for i, peer in lb:iter() do
+                ngx.say("1. ", peer.host)
+            end
+
+            ngx.say()
+            for i, peer in lb:iter() do
+                ngx.say("2. ", peer.host)
+            end
+
+            ngx.say()
+            for i, peer in lb:iter() do
+                ngx.say("3. ", peer.host)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+req_dc_rack_aware_round_robin
+local_dc: dc1
+local_rack: rack1
+
+1. 127.0.0.1
+1. 127.0.0.2
+1. 127.0.0.3
+1. 127.0.0.4
+1. 10.0.0.1
+1. 10.0.0.2
+
+2. 127.0.0.4
+2. 127.0.0.2
+2. 127.0.0.1
+2. 127.0.0.3
+2. 10.0.0.2
+2. 10.0.0.1
+
+3. 127.0.0.3
+3. 127.0.0.1
+3. 127.0.0.2
+3. 127.0.0.4
+3. 10.0.0.1
+3. 10.0.0.2
+--- no_error_log
+[error]
+
+
+
+=== TEST 2: lb_req_dc_rack_rr falls back to DC-only when local_rack omitted
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local lb_mod = require 'resty.cassandra.policies.lb.req_dc_rack_rr'
+
+            local peers = {
+                {host = '10.0.0.1', data_center = 'dc2', rack = 'rack1'},
+
+                {host = '127.0.0.1', data_center = 'dc1', rack = 'rack1'},
+                {host = '127.0.0.2', data_center = 'dc1', rack = 'rack2'},
+                {host = '127.0.0.3', data_center = 'dc1', rack = 'rack3'},
+            }
+
+            local lb = lb_mod.new('dc1')
+            lb:init(peers)
+
+            for i, peer in lb:iter() do
+                ngx.say(peer.host)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+127.0.0.1
+127.0.0.2
+127.0.0.3
+10.0.0.1
+--- no_error_log
+[error]
+
+
+
+=== TEST 3: lb_req_dc_rack_rr with missing local_dc
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local lb_mod = require 'resty.cassandra.policies.lb.req_dc_rack_rr'
+            local lb = lb_mod.new()
+        }
+    }
+--- request
+GET /t
+--- error_code: 500
+--- error_log
+local_dc must be a string
+--- no_error_log
+[crit]
+
+
+
+=== TEST 4: lb_req_dc_rack_rr with missing data_center and rack fields
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local lb_mod = require 'resty.cassandra.policies.lb.req_dc_rack_rr'
+
+            local peers = {
+                {host = '127.0.0.1', data_center = 'dc1', rack = 'rack1'},
+                {host = '127.0.0.2', data_center = 'dc1'},
+                {host = '127.0.0.3'},
+                {host = '10.0.0.1', data_center = 'dc2', rack = 'rack1'},
+            }
+
+            local lb = lb_mod.new('dc1', 'rack1')
+            lb:init(peers)
+
+            for i, peer in lb:iter() do
+                ngx.say(peer.host)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+127.0.0.1
+127.0.0.2
+127.0.0.3
+10.0.0.1
+--- error_log eval
+qr/\[warn\].*?\[lua-cassandra\] peer 127\.0\.0\.3 has no data_center field in shm, considering it remote/
+
+
+
+=== TEST 5: lb_req_dc_rack_rr returns same host first when invoked multiple times (request stickiness)
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local lb_mod = require 'resty.cassandra.policies.lb.req_dc_rack_rr'
+
+            local peers = {
+                {host = '10.0.0.1', data_center = 'dc2', rack = 'rack1'},
+
+                {host = '127.0.0.1', data_center = 'dc1', rack = 'rack1'},
+                {host = '127.0.0.2', data_center = 'dc1', rack = 'rack2'},
+                {host = '127.0.0.3', data_center = 'dc1', rack = 'rack1'},
+            }
+
+            local lb = lb_mod.new('dc1', 'rack1')
+            lb:init(peers)
+
+            for i, peer in lb:iter() do
+                ngx.say("1. ", peer.host)
+                break
+            end
+
+            for i, peer in lb:iter() do
+                ngx.say("2. ", peer.host)
+                break
+            end
+
+            for i, peer in lb:iter() do
+                ngx.say("3. ", peer.host)
+                break
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+1. 127.0.0.1
+2. 127.0.0.1
+3. 127.0.0.1
+--- no_error_log
+[error]
+
+
+
+=== TEST 6: lb_req_dc_rack_rr is resilient when ngx.ctx is 'nil'
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            if rawget(ngx, "ctx") == nil then
+                local __ngx_index = getmetatable(ngx)
+
+                setmetatable(ngx, {
+                    __index = function(t, k)
+                        if k == "ctx" then
+                            return
+                        end
+
+                        return __ngx_index(t, k)
+                    end
+                })
+
+            else
+                ngx.ctx = nil
+            end
+
+            local lb_mod = require 'resty.cassandra.policies.lb.req_dc_rack_rr'
+            ngx.say(lb_mod.name)
+
+            local peers = {
+                {host = '10.0.0.1', data_center = 'dc2', rack = 'rack1'},
+
+                {host = '127.0.0.1', data_center = 'dc1', rack = 'rack1'},
+                {host = '127.0.0.2', data_center = 'dc1', rack = 'rack1'},
+                {host = '127.0.0.3', data_center = 'dc1', rack = 'rack2'},
+            }
+
+            local lb = lb_mod.new('dc1', 'rack1')
+            lb:init(peers)
+
+            ngx.say()
+            for i, peer in lb:iter() do
+                ngx.say("1. ", peer.host)
+                break
+            end
+
+            for i, peer in lb:iter() do
+                ngx.say("2. ", peer.host)
+                break
+            end
+
+            for i, peer in lb:iter() do
+                ngx.say("3. ", peer.host)
+                break
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+req_dc_rack_aware_round_robin
+
+1. 127.0.0.1
+2. 127.0.0.2
+3. 127.0.0.1
+--- no_error_log
+[error]
+
+
+
+=== TEST 7: lb_req_dc_rack_rr with all peers in same rack (single AZ)
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local lb_mod = require 'resty.cassandra.policies.lb.req_dc_rack_rr'
+
+            local peers = {
+                {host = '127.0.0.1', data_center = 'dc1', rack = 'rack1'},
+                {host = '127.0.0.2', data_center = 'dc1', rack = 'rack1'},
+                {host = '127.0.0.3', data_center = 'dc1', rack = 'rack1'},
+            }
+
+            local lb = lb_mod.new('dc1', 'rack1')
+            lb:init(peers)
+
+            for i, peer in lb:iter() do
+                ngx.say(peer.host)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+127.0.0.1
+127.0.0.2
+127.0.0.3
+--- no_error_log
+[error]


### PR DESCRIPTION
### Problem

In cloud environments, Cassandra racks map to Availability Zones (AZs). Cross-AZ traffic incurs additional cost while intra-AZ traffic is free. The existing load balancing policies (`rr`, `dc_rr`, `req_dc_rr`) do not consider rack placement, causing requests to be routed to Cassandra nodes in arbitrary AZs and generating unnecessary cross-AZ charges.

### Solution

Introduce a new load balancing policy `req_dc_rack_rr` (request, datacenter, and rack-aware round robin) that prioritizes nodes in the same rack/AZ as the caller.

**Routing priority:**
1. Same rack, same DC (e.g. same AZ) — preferred
2. Other racks, same DC (e.g. other AZs in same region) — fallback
3. Remote DCs — last resort

If `local_rack` is not provided, the policy degrades gracefully to behave identically to `req_dc_rr`.

### Changes

**New files:**
- `lib/resty/cassandra/policies/lb/req_dc_rack_rr.lua` — The rack-aware LB policy
- `t/16-lb_req_dc_rack_rr.t` — Unit tests (3-tier ordering, fallback, missing fields, request stickiness, rotation)

**Modified files:**
- `lib/resty/cassandra/cluster.lua`
  - Added `rack` column to `system.local` and `system.peers` queries
  - Extended SHM serialization format to store `rack` alongside `data_center`, with backward compatibility for older entries
  - Propagated `rack` through `set_peer_down`, `set_peer_up`, and the local host record
  - Changed topology rebuild to use `set_peer` (overwrite) instead of `add_peer` (skip if exists), fixing a bug where DC/rack metadata was lost for nodes that were down during topology refresh
- `lib/cassandra/cql.lua`
  - Commented out references to unimplemented `decimal` type that caused `table index is nil` error on require

### Usage

```lua
local Cluster        = require "resty.cassandra.cluster"
local req_dc_rack_rr = require "resty.cassandra.policies.lb.req_dc_rack_rr"

local cluster, err = Cluster.new {
    shm            = "cassandra",
    contact_points = { "10.0.1.10", "10.0.2.10", "10.0.3.10" },
    lb_policy      = req_dc_rack_rr.new(
        os.getenv("CASSANDRA_LOCAL_DC"),    -- e.g. "us-west-2"
        os.getenv("CASSANDRA_LOCAL_RACK")   -- e.g. "us-west-2b"
    ),
}
```

### Test Plan

- [x] Unit tests pass (`t/16-lb_req_dc_rack_rr.t`)
- [x] Integration tested with 6-node Cassandra cluster (3 racks) via Docker Compose
- [x] Verified rack-aware routing: queries only go to same-rack nodes
- [x] Verified intra-rack failover: when one rack node is down, queries go to the other same-rack node
- [x] Verified cross-rack failover: when all same-rack nodes are down, queries fall back to other racks
- [x] Verified backward compatibility: SHM format handles old entries without rack field
